### PR TITLE
Nuovi link API e fix ortografiche

### DIFF
--- a/link-utili-bot.md
+++ b/link-utili-bot.md
@@ -2,15 +2,15 @@
 
 
 ## BIG & BOT
-- [GOOGLE](https://cloud.google.com/products/machine-learning/)  
-- [AMAZON](https://aws.amazon.com/it/machine-learning/)
-- [MICROSOFT](https://azure.microsoft.com/it-it/services/machine-learning/)
+- [Google](https://cloud.google.com/products/machine-learning/)  
+- [Amazon](https://aws.amazon.com/it/machine-learning/)
+- [Microsoft](https://azure.microsoft.com/it-it/services/machine-learning/)
 
 
 ## BOT as service e piattaforme
-- [API.AI - google company](https://api.ai/)  
-- [Dexter - Piattaforma per costruire BOT con dei Blocchi plug-and-play](https://rundexter.com)
-- [Wit.ai](https://wit.ai/) 
+- [Api.ai - Google company](https://api.ai/)  
+- [Dexter - Piattaforma per costruire BOT con dei blocchi plug-and-play](https://rundexter.com)
+- [Wit.ai - Facebook company](https://wit.ai/) 
 - [Recast.ai](https://recast.ai/) 
 - [PullString](https://www.pullstring.com/#panel-platforms)
 
@@ -20,40 +20,43 @@
 - [Milano Chatbots Meetup](http://www.meetup.com/it-IT/Milano-Chatbots-Meetup/)
 - [convcomp2016.it](https://medium.com/convcomp2016)
 
+
 ## Per gli smanettoni come me - Librerie e Framework
-- [ABOT- Crea un assistente digitale come Siri, Cortana, Google Now...](https://github.com/itsabot/abot) 
+- [ABOT - Crea un assistente digitale come Siri, Cortana, Google Now...](https://github.com/itsabot/abot) 
 - [Botkit opensource](https://howdy.ai/botkit/)
 - [Rob Ellis - superscriptjs and more](https://github.com/silentrob)  
 
-## Api:
-- [Api Facebook](https://www.facebook.com/BotDevelopers/) 
+
+## API
+- [API Facebook](https://www.facebook.com/BotDevelopers/) 
+- API Telegram: [introduzione](https://core.telegram.org/bots) e [reference](https://core.telegram.org/bots/api)
+- [API Skype](https://developer.microsoft.com/en-us/skype/bots)
+- [API Slack](https://api.slack.com/bot-users)
+- [API Spark)[https://developer.ciscospark.com/bots.html]
 
 
 ## Linguaggi specifici per BOT
 - [ChatScript](https://github.com/bwilcox-1234/ChatScript)
 - [RiverScipt](https://www.rivescript.com/)
-- [SuperScriptjs](http://superscriptjs.com/)  
+- [SuperScript](http://superscriptjs.com/)  
 - [PandoraBots](https://playground.pandorabots.com/it/)
 
-## Guide:
-- [Crea un bot facebook ste by step ](http://www.salvatorecordiano.it/creare-un-bot-facebook-guida-passo-passo/) 
+
+## Guide
+- [Crea un bot Facebook step by step](http://www.salvatorecordiano.it/creare-un-bot-facebook-guida-passo-passo/) 
 - [Crea un bot telegram step by step ](http://www.salvatorecordiano.it/creare-un-bot-telegram-guida-passo-passo/) 
 - [Come costruire un bot con ChatScript](https://medium.freecodecamp.com/chatscript-for-beginners-chatbots-developers-c58bb591da8#.qshjftyo) 
 
 
 ## Directory BOT
-- <b>+Utile </b>[Ruby Natural Language Processing Risorse](https://github.com/diasks2/ruby-nlp) 
+- <b>+Utile</b>[Ruby Natural Language Processing Risorse](https://github.com/diasks2/ruby-nlp) 
 
 
 ## Software House - Aziende produttrici 
 - [Bot Company](http://www.botcompany.it/)
 - [BotSociety](https://botsociety.io/) 
 
-## Gente che parla di BOTS
+
+## Gente che parla di BOT
 - [Paolo Montrasio](https://twitter.com/pmontrasio) 
 - [Giorgio Robino](https://twitter.com/solyarisoftware)
-
-
-
-
-


### PR DESCRIPTION
Aggiunti link alle API bot di altre chat oltre a Messenger.
Indicato che Wit è un'azienda di Facebook, poiché era indicato che Api.ai è di Google.
Rimosso un link duplicato alla guida di Cordiano.
Interventi tipografici:
- Sistemati i nomi di un po' di tecnologie ed aziende secondo la dizione ufficiale.
- Tolti i due punti finali da due titoli
- API è una sigla e va sempre in maiuscolo
- Decidere se scrivere sempre BOT o sempre bot, non si può usare un po' uno e un po' l'altro.
